### PR TITLE
Fix download / plain text URLs for hidden pastes

### DIFF
--- a/templates/include_hidden
+++ b/templates/include_hidden
@@ -100,8 +100,8 @@ Posted on [% comment.postedate %] by [% comment.name | html %]:</div>
 <b>This entry is hidden. So don't lose your hidden id ([% show %])</b>
 <ul>
 <li>To link to your entry use: <a href="[% base_url %]/hidden/[% show %]">[% base_url.substr(2) %]/hidden/[% show %]</a></li>
-<li>To download your entry use: <a href="[% base_url %]/downloadh/[% show %]">[% base_url.substr(2) %]/download_h/[% show %]</a></li>
-<li>To see your entry as plain text use: <a href="[% base_url %]/plainh/[% show %]">[% base_url.substr(2) %]/plain_h/[% show %]</a></li>
+<li>To download your entry use: <a href="[% base_url %]/downloadh/[% show %]">[% base_url.substr(2) %]/downloadh/[% show %]</a></li>
+<li>To see your entry as plain text use: <a href="[% base_url %]/plainh/[% show %]">[% base_url.substr(2) %]/plainh/[% show %]</a></li>
 <li>To delete your entry use: <a href="[% base_url %]/delete/[% post.sha1 %]">[% base_url.substr(2) %]/delete/[% post.sha1 %]</a></li>
 </ul>
 [% END -%]


### PR DESCRIPTION
The displayed URL and the actual href are different -- the former 404s in practice.